### PR TITLE
fix(indexer): query project database for file counts in background worker

### DIFF
--- a/src/services/background_worker.py
+++ b/src/services/background_worker.py
@@ -287,7 +287,7 @@ async def _background_indexing_worker(
         status_message = ""
 
         # Query database to determine if this was incremental or full index
-        async with AsyncSession(engine) as session:
+        async with get_session(project_id=project_id, ctx=None) as session:
             # Count total non-deleted files in database for this repository
             count_result = await session.execute(
                 select(func.count(CodeFile.id)).where(


### PR DESCRIPTION
## Bug Fix: Background Indexing Database Query

### Problem
Background indexing jobs showed `files_indexed=0` and `chunks_created=0` even though data was successfully written to the project database. This made it appear that indexing was failing when it was actually working correctly.

### Root Cause
**File**: `src/services/background_worker.py:290`

The post-indexing file count query used `AsyncSession(engine)` which connected to the main `codebase_mcp` database, but `CodeFile` records only exist in project-specific databases (e.g., `cb_proj_commission_processing_vendor_e_aabbccdd`).

### The Fix
Changed line 290 from:
```python
async with AsyncSession(engine) as session:
```

To:
```python
async with get_session(project_id=project_id, ctx=None) as session:
```

This ensures the file count query runs against the correct project database where `CodeFile` records were written.

### Impact
- **Files changed**: 1
- **Lines changed**: 1
- **Breaking changes**: None
- **Migration required**: No

### Verification
Tested with commission-processing-vendor-extractors repository:
- ✅ 837 files indexed
- ✅ 9,215 chunks created
- ✅ All data written to correct project database
- ✅ Job status now shows accurate counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)